### PR TITLE
Add student history consultation

### DIFF
--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/MenuActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/MenuActivity.kt
@@ -97,7 +97,9 @@ class MenuActivity : AppCompatActivity() {
             )
             "MATRICULADOR" -> listOf("Matrículas" to MatriculaFragment())
             "PROFESOR" -> emptyList()
-            "ALUMNO" -> emptyList()
+            "ALUMNO" -> listOf(
+                "Historial" to HistorialFragment()
+            )
             else -> emptyList()
         }
     }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/adapter/MenuAdapter.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/adapter/MenuAdapter.kt
@@ -45,6 +45,7 @@ class MenuAdapter(
             "grupos" -> holder.icono.setImageResource(R.drawable.ic_school)
             "matrículas" -> holder.icono.setImageResource(R.drawable.ic_school)
             "plan de estudio" -> holder.icono.setImageResource(R.drawable.ic_school)
+            "historial" -> holder.icono.setImageResource(R.drawable.ic_menu_book)
             else -> holder.icono.setImageResource(R.drawable.ic_school)
         }
     }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/HistorialFragment.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/HistorialFragment.kt
@@ -1,0 +1,66 @@
+package com.example.quiz1.fragment
+
+import android.content.Context.MODE_PRIVATE
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.example.quiz1.R
+import com.example.quiz1.api.ApiClient
+import com.example.quiz1.api.MatriculaApi
+import com.example.quiz1.adapter.MatriculaAdapter
+import com.example.quiz1.model.Matricula
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+class HistorialFragment : Fragment() {
+
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var adapter: MatriculaAdapter
+    private val lista = mutableListOf<Matricula>()
+    private val api = ApiClient.retrofit.create(MatriculaApi::class.java)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val view = inflater.inflate(R.layout.fragment_historial, container, false)
+        recyclerView = view.findViewById(R.id.recyclerViewHistorial)
+        adapter = MatriculaAdapter(lista) { }
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        recyclerView.adapter = adapter
+
+        val prefs = requireActivity().getSharedPreferences("datos_usuario", MODE_PRIVATE)
+        prefs.getString("cedula", null)?.let { cargarHistorial(it) }
+
+        return view
+    }
+
+    private fun cargarHistorial(cedula: String) {
+        api.listarPorAlumno(cedula).enqueue(object : Callback<List<Matricula>> {
+            override fun onResponse(
+                call: Call<List<Matricula>>,
+                response: Response<List<Matricula>>
+            ) {
+                if (response.isSuccessful) {
+                    lista.clear()
+                    lista.addAll(response.body() ?: emptyList())
+                    adapter.actualizarLista(lista)
+                } else {
+                    Toast.makeText(requireContext(), "Error al cargar", Toast.LENGTH_SHORT).show()
+                }
+            }
+
+            override fun onFailure(call: Call<List<Matricula>>, t: Throwable) {
+                Toast.makeText(requireContext(), "Fallo: ${t.message}", Toast.LENGTH_SHORT).show()
+            }
+        })
+    }
+}
+

--- a/Lab4_Moviles/app/src/main/res/layout/fragment_historial.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/fragment_historial.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="8dp">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewHistorial"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add HistorialFragment for students to view their matriculas
- show Historial option in menu when logged in as student
- display icon for new menu option

## Testing
- `./gradlew test` *(fails: environment missing requirements)*
- `./gradlew test` in backend *(fails: environment missing requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68404dbe1e94832fa1fa77840b38e0e9