### PR TITLE
Add history fetch script

### DIFF
--- a/Laboratorio_Gym_Backend/get_historial.sh
+++ b/Laboratorio_Gym_Backend/get_historial.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Script to fetch matricula history for sample students S001 and S002
+# It calls the API endpoints provided by the backend server
+
+API_BASE="http://localhost:8080/api/matriculas/alumno"
+for cedula in S001 S002; do
+  echo "Fetching historial for student $cedula"
+  curl -s "${API_BASE}/$cedula"
+  echo -e "\n"
+done


### PR DESCRIPTION
## Summary
- add a helper script `get_historial.sh` to retrieve enrollment history for sample students

## Testing
- `./Laboratorio_Gym_Backend/Gym_Backend/gradlew test --console=plain`
- `./Lab4_Moviles/gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405a97b030832f9e6dcec18f17da9e