### PR TITLE
Add sample historial data and update docs

### DIFF
--- a/Laboratorio_Gym_Backend/README.md
+++ b/Laboratorio_Gym_Backend/README.md
@@ -1,2 +1,11 @@
 # Laboratorio_Gym_Backend
-Laboratorio #1 Curso Diseño Móviles
+
+Backend de ejemplo para el laboratorio de Diseño de Aplicaciones Móviles. El
+script `Script.sql` contiene la definición completa de la base de datos y datos
+de prueba.  Puede ejecutarse utilizando la tarea `run` de Gradle:
+
+```bash
+./gradlew run
+```
+
+Por defecto el servidor se inicia en `http://localhost:8000`.

--- a/Laboratorio_Gym_Backend/Script.sql
+++ b/Laboratorio_Gym_Backend/Script.sql
@@ -873,8 +873,27 @@ VALUES (
 );
 
 
+-- Matrícula del estudiante S002 con nota asignada
 INSERT INTO matricula (cedulaAlumno, idGrupo, nota)
-VALUES ('S002', 1, NULL);
+VALUES ('S002', 1, 85);
+
+-- Grupo adicional impartido por el profesor P001
+INSERT INTO grupo (idCiclo, idCurso, numGrupo, horario, idProfesor)
+VALUES (
+    1,
+    (SELECT idcurso FROM curso WHERE codigo = 'CS101'),
+    2,
+    'Martes y Jueves 08:00-10:00',
+    'P001'
+);
+
+-- Matrícula del estudiante S001 en el grupo anterior con nota
+INSERT INTO matricula (cedulaAlumno, idGrupo, nota)
+VALUES (
+    'S001',
+    (SELECT idGrupo FROM grupo WHERE idCurso = (SELECT idcurso FROM curso WHERE codigo = 'CS101') AND numGrupo = 2 AND idProfesor = 'P001'),
+    90
+);
 
 COMMIT;
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # GestionAcademica_Lab04
+
+Este repositorio contiene un ejemplo de aplicación de gestión académica
+compuesto por un **backend** Java (carpeta `Laboratorio_Gym_Backend`) y una
+aplicación Android (carpeta `Lab4_Moviles`).
+
+## Cómo probar el sistema de historial y registro de notas
+
+1. Importe el script `Laboratorio_Gym_Backend/Script.sql` en su base de datos
+   Oracle.  Este script crea las tablas y registra datos de ejemplo para los
+   alumnos `S001` y `S002`, así como dos grupos impartidos por los profesores
+   `P001` y `P002`.  Ambos alumnos cuentan con matrículas que incluyen una nota
+   inicial.
+2. Desde la carpeta `Laboratorio_Gym_Backend/Gym_Backend` ejecute:
+
+   ```bash
+   ./gradlew run
+   ```
+
+   Esto iniciará el servidor en `http://localhost:8000`.
+3. Compile la aplicación Android ubicada en `Lab4_Moviles` utilizando Android
+   Studio.  Al ingresar como `S001` o `S002` podrá visualizar el historial de
+   matrículas.  Si ingresa como profesor (`P001` o `P002`) se mostrará la lista
+   de cursos que imparte para registrar notas.


### PR DESCRIPTION
## Summary
- seed extra sample groups and matriculas including grades for S001 and S002
- document how to run backend and mobile app

## Testing
- `./gradlew test` in `Laboratorio_Gym_Backend/Gym_Backend`
- `./gradlew test` in `Lab4_Moviles` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405d22a2a8832f9b9919e0605fb81d