### PR TITLE
Fix historial data display bug

### DIFF
--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/HistorialFragment.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/HistorialFragment.kt
@@ -49,9 +49,10 @@ class HistorialFragment : Fragment() {
                 response: Response<List<Matricula>>
             ) {
                 if (response.isSuccessful) {
+                    val datos = response.body() ?: emptyList()
                     lista.clear()
-                    lista.addAll(response.body() ?: emptyList())
-                    adapter.actualizarLista(lista)
+                    lista.addAll(datos)
+                    adapter.actualizarLista(datos)
                 } else {
                     Toast.makeText(requireContext(), "Error al cargar", Toast.LENGTH_SHORT).show()
                 }


### PR DESCRIPTION
## Summary
- fix updating the adapter in `HistorialFragment`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684087f21c8c832fb582b3f6ec916d75