### PR TITLE
Actualizar consulta de grupos del profesor

### DIFF
--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/NotasFragment.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/NotasFragment.kt
@@ -17,6 +17,7 @@ import com.example.quiz1.adapter.NotasAdapter
 import com.example.quiz1.api.ApiClient
 import com.example.quiz1.api.GrupoApi
 import com.example.quiz1.api.MatriculaApi
+import com.example.quiz1.util.Constantes
 import com.example.quiz1.model.Grupo
 import com.example.quiz1.model.Matricula
 import retrofit2.Call
@@ -54,7 +55,7 @@ class NotasFragment : Fragment() {
     private fun cargarGruposProfesor() {
         val prefs = requireActivity().getSharedPreferences("datos_usuario", MODE_PRIVATE)
         val cedula = prefs.getString("cedula", null) ?: return
-        apiGrupo.listar().enqueue(object : Callback<List<Grupo>> {
+        apiGrupo.listarPorProfesor(cedula, Constantes.CICLO_ACTUAL).enqueue(object : Callback<List<Grupo>> {
             override fun onResponse(call: Call<List<Grupo>>, response: Response<List<Grupo>>) {
                 if (response.isSuccessful) {
                     listaGrupos.clear()

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/util/Constantes.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/util/Constantes.kt
@@ -1,0 +1,5 @@
+package com.example.quiz1.util
+
+object Constantes {
+    const val CICLO_ACTUAL = 1
+}


### PR DESCRIPTION
## Summary
- agregar constante con el ciclo actual
- usar el endpoint `listarPorProfesor` en `NotasFragment` para filtrar grupos del docente

## Testing
- `./gradlew test` *(falló: no se encontró ANDROID_HOME)*
- `./gradlew test` en `Laboratorio_Gym_Backend/Gym_Backend`

------
https://chatgpt.com/codex/tasks/task_e_6840e311fef0832f944eafe344ca46be