### PR TITLE
Implement RegistrarNota flow

### DIFF
--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/util/Constantes.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/util/Constantes.kt
@@ -1,5 +1,7 @@
 package com.example.quiz1.util
 
 object Constantes {
-    const val CICLO_ACTUAL = 1
+    // Ciclo lectivo utilizado para filtrar los datos en el backend.
+    // Se ajusta a 50 para que coincida con los registros de prueba.
+    const val CICLO_ACTUAL = 50
 }

--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ aplicación Android (carpeta `Lab4_Moviles`).
 Los profesores pueden consultar sus grupos actuales mediante el endpoint
 `/api/grupos/profesor/{cedula}/ciclo/{idCiclo}` y registrar notas utilizando el
 endpoint `/api/matriculas/grupo/{idGrupo}` para obtener la lista de estudiantes.
+
+Para registrar y modificar notas desde la app, diríjase al menú "Registro de notas".
+Allí se muestran los grupos del profesor actual.
+Al seleccionar un grupo se cargan automáticamente los estudiantes matriculados y su nota.
+Tocando un estudiante se abre la actividad RegistrarNota donde puede editarse la calificación.


### PR DESCRIPTION
## Summary
- document professor's grade registration feature in README
- update cycle constant to 50 for test data

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ff819278832fae114d38b8e2412f