### PR TITLE
Fix RecyclerView layout and adapter logs

### DIFF
--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/adapter/MatriculaAdapter.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/adapter/MatriculaAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.widget.Filter
 import android.widget.Filterable
 import android.widget.TextView
+import android.util.Log
 import androidx.recyclerview.widget.RecyclerView
 import com.example.quiz1.R
 import com.example.quiz1.model.Matricula
@@ -25,6 +26,7 @@ class MatriculaAdapter(
     }
 
     override fun onBindViewHolder(holder: MatriculaViewHolder, position: Int) {
+        Log.d("MatriculaAdapter", "Renderizando posición $position con ${matriculasFiltradas[position].cedulaAlumno}")
         holder.bind(matriculasFiltradas[position])
     }
 
@@ -33,10 +35,12 @@ class MatriculaAdapter(
     fun getItem(pos: Int): Matricula = matriculasFiltradas[pos]
 
     fun actualizarLista(nuevaLista: List<Matricula>) {
+        Log.d("MatriculaAdapter", "Actualizar lista con ${nuevaLista.size} elementos")
         matriculas.clear()
         matriculas.addAll(nuevaLista)
         matriculasFiltradas = nuevaLista.toMutableList()
         notifyDataSetChanged()
+        Log.d("MatriculaAdapter", "Items en adapter: ${itemCount}")
     }
 
     override fun getFilter(): Filter {
@@ -71,6 +75,7 @@ class MatriculaAdapter(
         private val tvNota: TextView = itemView.findViewById(R.id.tvNota)
 
         fun bind(matricula: Matricula) {
+            Log.d("MatriculaAdapter", "Bind matricula ID: ${matricula.idMatricula}, Alumno: ${matricula.cedulaAlumno}")
             tvIdMatricula.text = "ID: ${matricula.idMatricula}"
             tvCedulaAlumno.text = "Alumno: ${matricula.cedulaAlumno}"
             tvIdGrupo.text = "Grupo: ${matricula.idGrupo}"

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/RegistroNotasFragment.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/RegistroNotasFragment.kt
@@ -131,6 +131,7 @@ class RegistroNotasFragment : Fragment() {
                     listaMatriculas.addAll(response.body() ?: emptyList())
                     Log.d("RegistroNotas", "Matrículas cargadas: ${listaMatriculas.size}")
                     adapter.actualizarLista(listaMatriculas)
+                    Log.d("RegistroNotas", "ItemCount después de actualizar: ${adapter.itemCount}")
                 } else {
                     Toast.makeText(requireContext(), "Error al cargar matrículas", Toast.LENGTH_SHORT).show()
                 }

--- a/Lab4_Moviles/app/src/main/res/layout/fragment_registro_notas.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/fragment_registro_notas.xml
@@ -13,7 +13,8 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerViewNotas"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="8dp"/>
+        android:layout_height="0dp"
+        android:layout_marginTop="8dp"
+        android:layout_weight="1"/>
 
 </LinearLayout>

--- a/Lab4_Moviles/app/src/main/res/layout/item_matricula.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/item_matricula.xml
@@ -5,13 +5,16 @@
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
     android:padding="8dp"
+    android:minHeight="48dp"
     android:elevation="4dp"
     android:radius="8dp">
 
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:background="@android:color/white">
 
         <TextView
             android:id="@+id/tvIdMatricula"


### PR DESCRIPTION
## Summary
- resize RecyclerView in `fragment_registro_notas` using layout weight
- style matricula item with padding, background, and min height
- add diagnostic logs in `MatriculaAdapter`
- log adapter item count after updating in `RegistroNotasFragment`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684114a5cff4832fbd8cdff5e604dcd1