### PR TITLE
Implement theme colors and add cancel options

### DIFF
--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/LoginActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/LoginActivity.kt
@@ -23,6 +23,7 @@ class LoginActivity : AppCompatActivity() {
         val etContrasena = findViewById<EditText>(R.id.etContrasena)
         val btnLogin = findViewById<Button>(R.id.btnLogin)
         val tvRegistro = findViewById<TextView>(R.id.tvRegistro)
+        val btnSalir = findViewById<Button>(R.id.btnSalir)
 
         val prefs = getSharedPreferences("datos_usuario", MODE_PRIVATE)
         val api = ApiClient.retrofit.create(LoginApi::class.java)
@@ -65,5 +66,7 @@ class LoginActivity : AppCompatActivity() {
         tvRegistro.setOnClickListener {
             startActivity(Intent(this, InscriptionActivity::class.java))
         }
+
+        btnSalir.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/carreraActivity/InsertarCarreraActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/carreraActivity/InsertarCarreraActivity.kt
@@ -20,6 +20,7 @@ class InsertarCarreraActivity : AppCompatActivity() {
     private lateinit var edtNombre: EditText
     private lateinit var edtTitulo: EditText
     private lateinit var btnGuardar: Button
+    private lateinit var btnCancelar: Button
 
     private val api = ApiClient.retrofit.create(CarreraApi::class.java)
 
@@ -33,6 +34,7 @@ class InsertarCarreraActivity : AppCompatActivity() {
         edtNombre    = findViewById(R.id.edtNombre)
         edtTitulo    = findViewById(R.id.edtTitulo)
         btnGuardar   = findViewById(R.id.btnGuardar)
+        btnCancelar  = findViewById(R.id.btnCancelar)
 
         // 2) Hacer el campo de ID no editable:
         edtIdCarrera.isEnabled = false
@@ -83,5 +85,7 @@ class InsertarCarreraActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/CarrerasFragment.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/CarrerasFragment.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.*
+import android.widget.Button
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
@@ -73,6 +74,10 @@ class CarrerasFragment : Fragment() {
 
         v.findViewById<View>(R.id.fabCarreras).setOnClickListener {
             launcherInsert.launch(Intent(requireContext(), InsertarCarreraActivity::class.java))
+        }
+
+        v.findViewById<Button>(R.id.btnSalir)?.setOnClickListener {
+            requireActivity().onBackPressedDispatcher.onBackPressed()
         }
 
         cargarCarreras()

--- a/Lab4_Moviles/app/src/main/res/layout/activity_insertar_carrera.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_insertar_carrera.xml
@@ -48,7 +48,18 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
+            android:minHeight="48dp"
             android:text="Guardar" />
+
+        <!-- Botón Cancelar -->
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Cancelar" />
 
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_login.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_login.xml
@@ -38,4 +38,14 @@
         android:textSize="14sp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
+
+    <!-- Botón Salir -->
+    <Button
+        android:id="@+id/btnSalir"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:minHeight="48dp"
+        android:text="Salir"
+        android:contentDescription="Salir" />
 </LinearLayout>

--- a/Lab4_Moviles/app/src/main/res/layout/fragment_carreras.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/fragment_carreras.xml
@@ -16,4 +16,15 @@
         android:layout_gravity="bottom|end"
         android:layout_margin="16dp"
         android:src="@android:drawable/ic_input_add"/>
+
+    <!-- Botón Salir -->
+    <Button
+        android:id="@+id/btnSalir"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|start"
+        android:layout_margin="16dp"
+        android:minHeight="48dp"
+        android:text="Salir"
+        android:contentDescription="Salir" />
 </FrameLayout>

--- a/Lab4_Moviles/app/src/main/res/values-night/colors.xml
+++ b/Lab4_Moviles/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="red_primary">#BB86FC</color>
+    <color name="red_primary_variant">#BB86FC</color>
+    <color name="red_accent">#BB86FC</color>
+    <color name="background">#121212</color>
+    <color name="textColor">#FFFFFF</color>
+    <color name="divider">#373737</color>
+</resources>

--- a/Lab4_Moviles/app/src/main/res/values-night/themes.xml
+++ b/Lab4_Moviles/app/src/main/res/values-night/themes.xml
@@ -1,3 +1,9 @@
 <resources>
-    <style name="Theme.Quiz1" parent="Theme.Material3.DayNight.NoActionBar"/>
+    <style name="Theme.Quiz1" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/red_primary</item>
+        <item name="colorPrimaryDark">@color/red_primary_variant</item>
+        <item name="colorOnPrimary">@color/textColor</item>
+        <item name="android:colorBackground">@color/background</item>
+        <item name="colorOnBackground">@color/textColor</item>
+    </style>
 </resources>

--- a/Lab4_Moviles/app/src/main/res/values/colors.xml
+++ b/Lab4_Moviles/app/src/main/res/values/colors.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
-    <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
+    <color name="red_primary">#D32F2F</color>
+    <color name="red_primary_variant">#B71C1C</color>
+    <color name="red_accent">#FF5252</color>
+    <color name="background">#FAFAFA</color>
+    <color name="textColor">#000000</color>
 </resources>

--- a/Lab4_Moviles/app/src/main/res/values/themes.xml
+++ b/Lab4_Moviles/app/src/main/res/values/themes.xml
@@ -1,8 +1,9 @@
 <resources>
     <style name="Theme.Quiz1" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Colores principales para respetar el modo claro y oscuro -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryDark">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
+        <item name="colorPrimary">@color/red_primary</item>
+        <item name="colorPrimaryDark">@color/red_primary_variant</item>
+        <item name="colorOnPrimary">@color/textColor</item>
+        <item name="android:colorBackground">@color/background</item>
+        <item name="colorOnBackground">@color/textColor</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- update light theme with red accents
- add dark theme colors
- hook light and dark color values in the themes
- add cancel/exit buttons to login and career screens
- allow exiting from CarrerasFragment

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685369709778832f9f4820d88da2c763