### PR TITLE
Improve CRUD UX and fix ActivityResult registration

### DIFF
--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/UsuarioActivity/EditarUsuarioActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/UsuarioActivity/EditarUsuarioActivity.kt
@@ -18,6 +18,7 @@ class EditarUsuarioActivity : AppCompatActivity() {
     private lateinit var edtClave:  EditText
     private lateinit var edtRol:    EditText
     private lateinit var btnActualizar: Button
+    private lateinit var btnCancelar: Button
 
     private val api = ApiClient.retrofit.create(UsuarioApi::class.java)
     private var cedulaOriginal: String = ""
@@ -30,6 +31,7 @@ class EditarUsuarioActivity : AppCompatActivity() {
         edtClave   = findViewById(R.id.edtClaveUsuario)
         edtRol     = findViewById(R.id.edtRolUsuario)
         btnActualizar = findViewById(R.id.btnActualizarUsuario)
+        btnCancelar = findViewById(R.id.btnCancelar)
 
         // Recibir el Usuario pasado desde el fragment
         val usuarioRecibido = intent.getSerializableExtra("usuario") as? Usuario
@@ -65,5 +67,7 @@ class EditarUsuarioActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/UsuarioActivity/InsertarUsuarioActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/UsuarioActivity/InsertarUsuarioActivity.kt
@@ -18,6 +18,7 @@ class InsertarUsuarioActivity : AppCompatActivity() {
     private lateinit var edtClave:  EditText
     private lateinit var edtRol:    EditText
     private lateinit var btnGuardar: Button
+    private lateinit var btnCancelar: Button
 
     private val api = ApiClient.retrofit.create(UsuarioApi::class.java)
 
@@ -29,6 +30,7 @@ class InsertarUsuarioActivity : AppCompatActivity() {
         edtClave   = findViewById(R.id.edtClaveUsuario)
         edtRol     = findViewById(R.id.edtRolUsuario)
         btnGuardar = findViewById(R.id.btnGuardarUsuario)
+        btnCancelar = findViewById(R.id.btnCancelar)
 
         btnGuardar.setOnClickListener {
             val usuario = Usuario(
@@ -57,5 +59,7 @@ class InsertarUsuarioActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/alumnoActivity/EditarAlumnoActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/alumnoActivity/EditarAlumnoActivity.kt
@@ -21,6 +21,7 @@ class EditarAlumnoActivity : AppCompatActivity() {
     private lateinit var edtFechaNacimiento: EditText
     private lateinit var edtIdCarrera: EditText
     private lateinit var btnActualizar: Button
+    private lateinit var btnCancelar: Button
 
     private val api = ApiClient.retrofit.create(AlumnoApi::class.java)
     private var idAlumno = 0
@@ -36,6 +37,7 @@ class EditarAlumnoActivity : AppCompatActivity() {
         edtFechaNacimiento = findViewById(R.id.edtFechaNacimiento)
         edtIdCarrera = findViewById(R.id.edtIdCarrera)
         btnActualizar = findViewById(R.id.btnActualizar)
+        btnCancelar = findViewById(R.id.btnCancelar)
 
         val alumno = intent.getSerializableExtra("alumno") as? Alumno
         alumno?.let {
@@ -85,5 +87,7 @@ class EditarAlumnoActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/alumnoActivity/InsertarAlumnoActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/alumnoActivity/InsertarAlumnoActivity.kt
@@ -21,6 +21,7 @@ class InsertarAlumnoActivity : AppCompatActivity() {
     private lateinit var edtFechaNacimiento: EditText
     private lateinit var edtIdCarrera: EditText
     private lateinit var btnGuardar: Button
+    private lateinit var btnCancelar: Button
 
     private val api = ApiClient.retrofit.create(AlumnoApi::class.java)
 
@@ -35,8 +36,10 @@ class InsertarAlumnoActivity : AppCompatActivity() {
         edtFechaNacimiento = findViewById(R.id.edtFechaNacimiento)
         edtIdCarrera = findViewById(R.id.edtIdCarrera)
         btnGuardar = findViewById(R.id.btnGuardar)
+        btnCancelar = findViewById(R.id.btnCancelar)
 
         btnGuardar.setOnClickListener { insertarAlumno() }
+        btnCancelar.setOnClickListener { finish() }
     }
 
     private fun insertarAlumno() {

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/carreraActivity/EditarCarreraActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/carreraActivity/EditarCarreraActivity.kt
@@ -19,6 +19,7 @@ class EditarCarreraActivity : AppCompatActivity() {
     private lateinit var edtNombre: EditText
     private lateinit var edtTitulo: EditText
     private lateinit var btnActualizar: Button
+    private lateinit var btnCancelar: Button
     private val api = ApiClient.retrofit.create(CarreraApi::class.java)
     private var idCarrera = 0
 
@@ -29,6 +30,7 @@ class EditarCarreraActivity : AppCompatActivity() {
         edtNombre = findViewById(R.id.edtNombreCarrera)
         edtTitulo = findViewById(R.id.edtTituloCarrera)
         btnActualizar = findViewById(R.id.btnActualizarCarrera)
+        btnCancelar = findViewById(R.id.btnCancelar)
 
         val c = intent.getSerializableExtra("carrera") as? Carrera
         c?.let {
@@ -39,6 +41,7 @@ class EditarCarreraActivity : AppCompatActivity() {
         }
 
         btnActualizar.setOnClickListener { actualizar() }
+        btnCancelar.setOnClickListener { finish() }
     }
 
     private fun actualizar(){

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/cicloActivity/EditarCicloActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/cicloActivity/EditarCicloActivity.kt
@@ -20,6 +20,7 @@ class EditarCicloActivity : AppCompatActivity() {
     private lateinit var edtInicio: EditText
     private lateinit var edtFin: EditText
     private lateinit var btnActualizar: Button
+    private lateinit var btnCancelar: Button
     private val api = ApiClient.retrofit.create(CicloApi::class.java)
     private var idCiclo = 0
 
@@ -33,6 +34,7 @@ class EditarCicloActivity : AppCompatActivity() {
         edtInicio   = findViewById(R.id.edtFechaInicio)
         edtFin        = findViewById(R.id.edtFechaFin)
         btnActualizar = findViewById(R.id.btnActualizar)
+        btnCancelar = findViewById(R.id.btnCancelar)
 
         val c = intent.getSerializableExtra("ciclo") as? Ciclo
         c?.let {
@@ -64,5 +66,7 @@ class EditarCicloActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/cicloActivity/InsertarCicloActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/cicloActivity/InsertarCicloActivity.kt
@@ -19,6 +19,7 @@ class InsertarCicloActivity : AppCompatActivity() {
     private lateinit var edtInicio: EditText
     private lateinit var edtFin: EditText
     private lateinit var btnGuardar: Button
+    private lateinit var btnCancelar: Button
     private val api = ApiClient.retrofit.create(CicloApi::class.java)
 
     override fun onCreate(s: Bundle?) {
@@ -29,6 +30,7 @@ class InsertarCicloActivity : AppCompatActivity() {
         edtInicio  = findViewById(R.id.edtFechaInicio)
         edtFin     = findViewById(R.id.edtFechaFin)
         btnGuardar = findViewById(R.id.btnGuardar)
+        btnCancelar = findViewById(R.id.btnCancelar)
 
         btnGuardar.setOnClickListener {
             val c = Ciclo(
@@ -49,5 +51,7 @@ class InsertarCicloActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/cursoActivity/EditarCursoActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/cursoActivity/EditarCursoActivity.kt
@@ -25,6 +25,7 @@ class EditarCursoActivity : AppCompatActivity() {
         val edtCreditos = findViewById<EditText>(R.id.edtCreditosCurso)
         val edtHoras = findViewById<EditText>(R.id.edtHorasCurso)
         val btnActualizar = findViewById<Button>(R.id.btnActualizarCurso)
+        val btnCancelar = findViewById<Button>(R.id.btnCancelar)
 
         edtCodigo.setText(curso.codigo)
         edtNombre.setText(curso.nombre)
@@ -52,5 +53,7 @@ class EditarCursoActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/cursoActivity/InsertarCursoActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/cursoActivity/InsertarCursoActivity.kt
@@ -23,6 +23,7 @@ class InsertarCursoActivity : AppCompatActivity() {
         val edtCreditos = findViewById<EditText>(R.id.edtCreditosCurso)
         val edtHoras = findViewById<EditText>(R.id.edtHorasCurso)
         val btnGuardar = findViewById<Button>(R.id.btnGuardarCurso)
+        val btnCancelar = findViewById<Button>(R.id.btnCancelar)
 
         btnGuardar.setOnClickListener {
             val nuevoCurso = Curso(
@@ -45,5 +46,7 @@ class InsertarCursoActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/grupoActivity/EditarGrupoActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/grupoActivity/EditarGrupoActivity.kt
@@ -27,6 +27,7 @@ class EditarGrupoActivity : AppCompatActivity() {
         val edtHorario = findViewById<EditText>(R.id.edtHorario)
         val edtProf    = findViewById<EditText>(R.id.edtIdProfesor)
         val btnAct     = findViewById<Button>(R.id.btnActualizar)
+        val btnCancelar = findViewById<Button>(R.id.btnCancelar)
 
         val g = intent.getSerializableExtra("grupo") as? Grupo
         g?.let {
@@ -65,5 +66,7 @@ class EditarGrupoActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/grupoActivity/InsertarGrupoActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/grupoActivity/InsertarGrupoActivity.kt
@@ -23,7 +23,10 @@ class InsertarGrupoActivity : AppCompatActivity() {
         val edtNum     = findViewById<EditText>(R.id.edtNumGrupo)
         val edtHorario = findViewById<EditText>(R.id.edtHorario)
         val edtProf    = findViewById<EditText>(R.id.edtIdProfesor)
-        findViewById<Button>(R.id.btnGuardar).setOnClickListener {
+        val btnGuardar = findViewById<Button>(R.id.btnGuardar)
+        val btnCancelar = findViewById<Button>(R.id.btnCancelar)
+
+        btnGuardar.setOnClickListener {
             val g = Grupo(
                 idGrupo = 0,
                 idCiclo = edtCiclo.text.toString().toIntOrNull() ?: 0,
@@ -50,5 +53,7 @@ class InsertarGrupoActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/matriculaActivity/EditarMatriculaActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/matriculaActivity/EditarMatriculaActivity.kt
@@ -19,6 +19,7 @@ class EditarMatriculaActivity : AppCompatActivity() {
     private lateinit var edtIdGrupo: EditText
     private lateinit var edtNota: EditText
     private lateinit var btnActualizar: Button
+    private lateinit var btnCancelar: Button
 
     private val api = ApiClient.retrofit.create(MatriculaApi::class.java)
     private var idMatricula = 0
@@ -31,6 +32,7 @@ class EditarMatriculaActivity : AppCompatActivity() {
         edtIdGrupo = findViewById(R.id.edtIdGrupo)
         edtNota = findViewById(R.id.edtNota)
         btnActualizar = findViewById(R.id.btnActualizarMatricula)
+        btnCancelar = findViewById(R.id.btnCancelar)
 
         val matricula = intent.getSerializableExtra("matricula") as? Matricula
         matricula?.let {
@@ -63,5 +65,7 @@ class EditarMatriculaActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/matriculaActivity/InsertarMatriculaActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/matriculaActivity/InsertarMatriculaActivity.kt
@@ -19,6 +19,7 @@ class InsertarMatriculaActivity : AppCompatActivity() {
     private lateinit var edtIdGrupo: EditText
     private lateinit var edtNota: EditText
     private lateinit var btnGuardar: Button
+    private lateinit var btnCancelar: Button
 
     private val api = ApiClient.retrofit.create(MatriculaApi::class.java)
 
@@ -30,10 +31,12 @@ class InsertarMatriculaActivity : AppCompatActivity() {
         edtIdGrupo = findViewById(R.id.edtIdGrupo)
         edtNota = findViewById(R.id.edtNota)
         btnGuardar = findViewById(R.id.btnGuardarMatricula)
+        btnCancelar = findViewById(R.id.btnCancelar)
 
         btnGuardar.setOnClickListener {
             insertarMatricula()
         }
+        btnCancelar.setOnClickListener { finish() }
     }
 
     private fun insertarMatricula() {

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/planEstudioActivity/EditarPlanEstudioActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/planEstudioActivity/EditarPlanEstudioActivity.kt
@@ -18,6 +18,7 @@ class EditarPlanEstudioActivity : AppCompatActivity() {
     private lateinit var etAnio: EditText
     private lateinit var etCiclo: EditText
     private lateinit var btnActualizar: Button
+    private lateinit var btnCancelar: Button
 
     private lateinit var planOriginal: PlanEstudio
 
@@ -31,6 +32,7 @@ class EditarPlanEstudioActivity : AppCompatActivity() {
         etAnio = findViewById(R.id.etAnioEditar)
         etCiclo = findViewById(R.id.etCicloEditar)
         btnActualizar = findViewById(R.id.btnActualizarPlan)
+        btnCancelar = findViewById(R.id.btnCancelar)
 
         // Obtenemos el plan recibido
         planOriginal = intent.getSerializableExtra("plan") as PlanEstudio
@@ -68,5 +70,7 @@ class EditarPlanEstudioActivity : AppCompatActivity() {
                     }
                 })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/planEstudioActivity/InsertarPlanEstudioActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/planEstudioActivity/InsertarPlanEstudioActivity.kt
@@ -20,6 +20,7 @@ class InsertarPlanEstudioActivity : AppCompatActivity() {
     private lateinit var etAnio: EditText
     private lateinit var etCiclo: EditText
     private lateinit var btnGuardar: Button
+    private lateinit var btnCancelar: Button
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,6 +31,7 @@ class InsertarPlanEstudioActivity : AppCompatActivity() {
         etAnio = findViewById(R.id.etAnio)
         etCiclo = findViewById(R.id.etCiclo)
         btnGuardar = findViewById(R.id.btnGuardarPlan)
+        btnCancelar = findViewById(R.id.btnCancelar)
 
         btnGuardar.setOnClickListener {
             val nuevoPlan = PlanEstudio(
@@ -56,5 +58,7 @@ class InsertarPlanEstudioActivity : AppCompatActivity() {
                     }
                 })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/profesorActivity/EditarProfesorActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/profesorActivity/EditarProfesorActivity.kt
@@ -27,6 +27,7 @@ class EditarProfesorActivity : AppCompatActivity() {
         val edtTelefono = findViewById<EditText>(R.id.edtTelefonoProfesor)
         val edtEmail    = findViewById<EditText>(R.id.edtEmailProfesor)
         val btnActualizar = findViewById<Button>(R.id.btnActualizarProfesor)
+        val btnCancelar  = findViewById<Button>(R.id.btnCancelar)
 
         profesorOriginal = intent.getSerializableExtra("profesor") as Profesor
         // Rellenamos campos con los datos existentes
@@ -60,5 +61,7 @@ class EditarProfesorActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/profesorActivity/InsertarProfesorActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/profesorActivity/InsertarProfesorActivity.kt
@@ -26,6 +26,7 @@ class InsertarProfesorActivity : AppCompatActivity() {
         val edtTelefono = findViewById<EditText>(R.id.edtTelefonoProfesor)
         val edtEmail    = findViewById<EditText>(R.id.edtEmailProfesor)
         val btnGuardar  = findViewById<Button>(R.id.btnGuardarProfesor)
+        val btnCancelar = findViewById<Button>(R.id.btnCancelar)
 
         btnGuardar.setOnClickListener {
             val nuevo = Profesor(
@@ -49,5 +50,7 @@ class InsertarProfesorActivity : AppCompatActivity() {
                 }
             })
         }
+
+        btnCancelar.setOnClickListener { finish() }
     }
 }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/AlumnosFragment.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/AlumnosFragment.kt
@@ -33,16 +33,8 @@ class AlumnosFragment : Fragment() {
     private val api = ApiClient.retrofit.create(AlumnoApi::class.java)
 
     // Lanzadores para recibir RESULT_OK y recargar
-    private val launcherInsertar = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) {
-        if (it.resultCode == Activity.RESULT_OK) cargarAlumnosDesdeApi()
-    }
-    private val launcherEditar = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) {
-        if (it.resultCode == Activity.RESULT_OK) cargarAlumnosDesdeApi()
-    }
+    private lateinit var launcherInsertar: ActivityResultLauncher<Intent>
+    private lateinit var launcherEditar: ActivityResultLauncher<Intent>
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -103,6 +95,16 @@ class AlumnosFragment : Fragment() {
         }
 
         return view
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        launcherInsertar = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode == Activity.RESULT_OK) cargarAlumnosDesdeApi()
+        }
+        launcherEditar = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode == Activity.RESULT_OK) cargarAlumnosDesdeApi()
+        }
     }
 
     private fun cargarAlumnosDesdeApi() {

--- a/Lab4_Moviles/app/src/main/res/layout/activity_editar_alumno.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_editar_alumno.xml
@@ -52,5 +52,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"/>
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_editar_carrera.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_editar_carrera.xml
@@ -31,5 +31,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"/>
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_editar_ciclo.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_editar_ciclo.xml
@@ -49,5 +49,14 @@
             android:layout_height="wrap_content"
             android:text="Actualizar"/>
 
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
+
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_editar_curso.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_editar_curso.xml
@@ -41,5 +41,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"/>
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_editar_grupo.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_editar_grupo.xml
@@ -15,5 +15,14 @@
         <EditText android:id="@+id/edtIdProfesor" android:hint="ID Profesor"  android:layout_width="match_parent" android:layout_height="wrap_content"/>
 
         <Button  android:id="@+id/btnActualizar"  android:text="Actualizar"   android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_editar_matricula.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_editar_matricula.xml
@@ -35,5 +35,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"/>
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_editar_plan_estudio.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_editar_plan_estudio.xml
@@ -43,5 +43,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp" />
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_editar_profesor.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_editar_profesor.xml
@@ -43,5 +43,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"/>
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_editar_usuario.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_editar_usuario.xml
@@ -35,5 +35,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp" />
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_insertar_alumno.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_insertar_alumno.xml
@@ -51,5 +51,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"/>
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_insertar_carrera.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_insertar_carrera.xml
@@ -59,7 +59,7 @@
             android:layout_marginTop="8dp"
             android:minHeight="48dp"
             android:text="Cancelar"
-            android:contentDescription="Cancelar" />
+            android:contentDescription="Botón para cancelar" />
 
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_insertar_ciclo.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_insertar_ciclo.xml
@@ -42,5 +42,14 @@
             android:layout_height="wrap_content"
             android:text="Guardar"/>
 
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
+
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_insertar_curso.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_insertar_curso.xml
@@ -41,5 +41,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"/>
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_insertar_grupo.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_insertar_grupo.xml
@@ -15,5 +15,14 @@
         <EditText android:id="@+id/edtIdProfesor"  android:hint="ID Profesor"  android:layout_width="match_parent" android:layout_height="wrap_content"/>
 
         <Button  android:id="@+id/btnGuardar"      android:text="Guardar"       android:layout_width="wrap_content"  android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_insertar_matricula.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_insertar_matricula.xml
@@ -35,5 +35,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"/>
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_insertar_plan_estudio.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_insertar_plan_estudio.xml
@@ -18,4 +18,13 @@
 
     <Button android:id="@+id/btnGuardarPlan" android:text="Guardar"
         android:layout_width="match_parent" android:layout_height="wrap_content" />
+
+    <Button
+        android:id="@+id/btnCancelar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:minHeight="48dp"
+        android:text="Cancelar"
+        android:contentDescription="Botón para cancelar" />
 </LinearLayout>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_insertar_profesor.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_insertar_profesor.xml
@@ -42,5 +42,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"/>
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/activity_insertar_usuario.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_insertar_usuario.xml
@@ -35,5 +35,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp" />
+
+        <Button
+            android:id="@+id/btnCancelar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:text="Cancelar"
+            android:contentDescription="Botón para cancelar" />
     </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/alumno_item.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/alumno_item.xml
@@ -1,4 +1,4 @@
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
@@ -47,4 +47,4 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
     </LinearLayout>
-</androidx.cardview.widget.CardView>
+</com.google.android.material.card.MaterialCardView>

--- a/Lab4_Moviles/app/src/main/res/layout/fragment_carreras.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/fragment_carreras.xml
@@ -15,16 +15,6 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:layout_margin="16dp"
-        android:src="@android:drawable/ic_input_add"/>
-
-    <!-- Botón Salir -->
-    <Button
-        android:id="@+id/btnSalir"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|start"
-        android:layout_margin="16dp"
-        android:minHeight="48dp"
-        android:text="Salir"
-        android:contentDescription="Salir" />
+        android:src="@android:drawable/ic_input_add"
+        android:contentDescription="Agregar carrera"/>
 </FrameLayout>

--- a/Lab4_Moviles/app/src/main/res/layout/fragment_ciclos.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/fragment_ciclos.xml
@@ -23,6 +23,7 @@
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
         android:layout_gravity="end|bottom"
-        android:src="@android:drawable/ic_input_add"/>
+        android:src="@android:drawable/ic_input_add"
+        android:contentDescription="Agregar ciclo"/>
 
 </LinearLayout>

--- a/Lab4_Moviles/app/src/main/res/layout/fragment_grupos.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/fragment_grupos.xml
@@ -23,6 +23,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
         android:layout_margin="16dp"
-        android:src="@android:drawable/ic_input_add" />
+        android:src="@android:drawable/ic_input_add"
+        android:contentDescription="Agregar grupo" />
 
 </LinearLayout>

--- a/Lab4_Moviles/app/src/main/res/layout/item_card_layout.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/item_card_layout.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    android:padding="16dp"
+    android:elevation="6dp"
+    android:radius="12dp">
+
+    <LinearLayout
+        android:id="@+id/content"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- add cancel button to CRUD screens and handle click
- use MaterialCardView style for student items
- remove exit button and add accessibility labels
- register ActivityResultLauncher in `onViewCreated`
- provide reusable card layout

## Testing
- `sh gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a92c37f8832fb6917ec42b760b05