### PR TITLE
Fix ViewHolder scope in adapters

### DIFF
--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/adapter/CarrerasAdapter.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/adapter/CarrerasAdapter.kt
@@ -12,19 +12,19 @@ import com.example.quiz1.R
 class CarrerasAdapter(private val items: List<Carrera>) :
     RecyclerView.Adapter<CarrerasAdapter.ViewHolder>() {
 
-    inner class ViewHolder(v: View) : RecyclerView.ViewHolder(v) {
-        private val line1: TextView = v.findViewById(R.id.tvLine1)
-        private val line2: TextView = v.findViewById(R.id.tvLine2)
-        private val line3: TextView = v.findViewById(R.id.tvLine3)
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val line1: TextView = itemView.findViewById(R.id.tvLine1)
+        private val line2: TextView = itemView.findViewById(R.id.tvLine2)
+        private val line3: TextView = itemView.findViewById(R.id.tvLine3)
 
         fun bind(carrera: Carrera) {
             line1.text = "Nombre: ${carrera.nombre}"
             line2.text = "Código: ${carrera.codigo}"
             line3.text = "Título: ${carrera.titulo}"
 
-            v.findViewById<TextView>(R.id.tvLine4)?.visibility = View.GONE
-            v.findViewById<TextView>(R.id.tvLine5)?.visibility = View.GONE
-            v.findViewById<TextView>(R.id.tvLine6)?.visibility = View.GONE
+            itemView.findViewById<TextView>(R.id.tvLine4)?.visibility = View.GONE
+            itemView.findViewById<TextView>(R.id.tvLine5)?.visibility = View.GONE
+            itemView.findViewById<TextView>(R.id.tvLine6)?.visibility = View.GONE
         }
     }
 

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/adapter/CiclosAdapter.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/adapter/CiclosAdapter.kt
@@ -14,12 +14,12 @@ class CiclosAdapter(private var listaOriginal: MutableList<Ciclo>) :
 
     private var listaFiltrada = listaOriginal.toMutableList()
 
-    inner class ViewHolder(v: View) : RecyclerView.ViewHolder(v) {
-        private val line1: TextView = v.findViewById(R.id.tvLine1)
-        private val line2: TextView = v.findViewById(R.id.tvLine2)
-        private val line3: TextView = v.findViewById(R.id.tvLine3)
-        private val line4: TextView = v.findViewById(R.id.tvLine4)
-        private val line5: TextView = v.findViewById(R.id.tvLine5)
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val line1: TextView = itemView.findViewById(R.id.tvLine1)
+        private val line2: TextView = itemView.findViewById(R.id.tvLine2)
+        private val line3: TextView = itemView.findViewById(R.id.tvLine3)
+        private val line4: TextView = itemView.findViewById(R.id.tvLine4)
+        private val line5: TextView = itemView.findViewById(R.id.tvLine5)
 
         fun bind(c: Ciclo) {
             line1.text = "ID: ${c.idCiclo}"
@@ -28,7 +28,7 @@ class CiclosAdapter(private var listaOriginal: MutableList<Ciclo>) :
             line4.text = "Inicio: ${c.fechaInicio}"
             line5.text = "Fin: ${c.fechaFin}"
 
-            v.findViewById<TextView>(R.id.tvLine6)?.visibility = View.GONE
+            itemView.findViewById<TextView>(R.id.tvLine6)?.visibility = View.GONE
         }
     }
 


### PR DESCRIPTION
## Summary
- use `itemView.findViewById` in CarrerasAdapter
- use `itemView.findViewById` in CiclosAdapter

## Testing
- `./gradlew test --console=plain --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853cbf72744832faf99614ceb7c1e79