### PR TITLE
Add onboarding and accessible help

### DIFF
--- a/Lab4_Moviles/app/src/main/AndroidManifest.xml
+++ b/Lab4_Moviles/app/src/main/AndroidManifest.xml
@@ -14,17 +14,23 @@
         android:theme="@style/Theme.Quiz1"
         android:networkSecurityConfig="@xml/network_security_config">
 
-        <!-- Pantalla de Login, lanzador de la app -->
+        <!-- Pantalla de bienvenida -->
         <activity
-            android:name=".activity.LoginActivity"
+            android:name=".activity.OnboardingActivity"
             android:exported="true"
-            android:label="@string/title_activity_login"
             android:theme="@style/Theme.Quiz1">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Pantalla de Login -->
+        <activity
+            android:name=".activity.LoginActivity"
+            android:exported="false"
+            android:label="@string/title_activity_login"
+            android:theme="@style/Theme.Quiz1" />
 
         <!-- Menú principal -->
         <activity

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/MenuActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/MenuActivity.kt
@@ -65,6 +65,8 @@ class MenuActivity : AppCompatActivity() {
         }
 
         items.addAll(obtenerItemsPorRol(rol))
+        // Todos los roles pueden acceder a la sección de ayuda
+        items.add("Ayuda" to AyudaFragment())
 
         val recyclerView = findViewById<RecyclerView>(R.id.menuRecyclerView)
         recyclerView.layoutManager = LinearLayoutManager(this)

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/OnboardingActivity.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/activity/OnboardingActivity.kt
@@ -1,0 +1,29 @@
+package com.example.quiz1.activity
+
+import android.content.Context.MODE_PRIVATE
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+import com.example.quiz1.R
+
+class OnboardingActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val prefs = getSharedPreferences("datos_usuario", MODE_PRIVATE)
+        if (prefs.getBoolean("onboarding_complete", false)) {
+            startActivity(Intent(this, LoginActivity::class.java))
+            finish()
+            return
+        }
+
+        setContentView(R.layout.activity_onboarding)
+
+        findViewById<Button>(R.id.btnContinuar).setOnClickListener {
+            prefs.edit().putBoolean("onboarding_complete", true).apply()
+            startActivity(Intent(this, LoginActivity::class.java))
+            finish()
+        }
+    }
+}

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/adapter/MenuAdapter.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/adapter/MenuAdapter.kt
@@ -47,6 +47,7 @@ class MenuAdapter(
             "plan de estudio" -> holder.icono.setImageResource(R.drawable.ic_school)
             "historial" -> holder.icono.setImageResource(R.drawable.ic_menu_book)
             "registro notas" -> holder.icono.setImageResource(R.drawable.ic_menu_book)
+            "ayuda" -> holder.icono.setImageResource(R.drawable.ic_menu_book)
             else -> holder.icono.setImageResource(R.drawable.ic_school)
         }
     }

--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/AyudaFragment.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/AyudaFragment.kt
@@ -1,0 +1,22 @@
+package com.example.quiz1.fragment
+
+import android.os.Bundle
+import android.text.method.LinkMovementMethod
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import com.example.quiz1.R
+
+class AyudaFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_ayuda, container, false)
+        view.findViewById<TextView>(R.id.tvContenidoAyuda).movementMethod = LinkMovementMethod.getInstance()
+        return view
+    }
+}

--- a/Lab4_Moviles/app/src/main/res/layout/activity_onboarding.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/activity_onboarding.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tvWelcome"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/onboarding_welcome"
+            android:textStyle="bold"
+            android:textSize="18sp"
+            android:layout_marginBottom="8dp" />
+
+        <TextView
+            android:id="@+id/tvInstructions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/onboarding_instructions"
+            android:layout_marginBottom="24dp" />
+
+        <Button
+            android:id="@+id/btnContinuar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/onboarding_continue" />
+    </LinearLayout>
+</ScrollView>

--- a/Lab4_Moviles/app/src/main/res/layout/fragment_ayuda.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/fragment_ayuda.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/tvContenidoAyuda"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:autoLink="email"
+        android:text="@string/help_text" />
+</ScrollView>

--- a/Lab4_Moviles/app/src/main/res/values/strings.xml
+++ b/Lab4_Moviles/app/src/main/res/values/strings.xml
@@ -7,4 +7,8 @@
     <string name="drawer_open">Abrir menú</string>
     <string name="drawer_close">Cerrar menú</string>
     <string name="menu_item_icon_desc">Ícono de opción de menú</string>
+    <string name="onboarding_welcome">Bienvenido a Gestión Académica</string>
+    <string name="onboarding_instructions">Usa el menú lateral para acceder a cada sección y gestionar tus datos académicos.</string>
+    <string name="onboarding_continue">Continuar</string>
+    <string name="help_text">Para más información sobre el uso de la app, abre el menú y elige la sección correspondiente. Si necesitas asistencia escribe a soporte@example.com.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add onboarding activity for first-time users
- provide help fragment with contact info
- include new menu item for help across all roles
- show onboarding screen on app launch

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `chmod +x gradlew && ./gradlew test` in `Laboratorio_Gym_Backend/Gym_Backend`

------
https://chatgpt.com/codex/tasks/task_e_6853d88aada8832fa0fd2c7c563efa75