### PR TITLE
Add detailed help screen

### DIFF
--- a/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/AyudaFragment.kt
+++ b/Lab4_Moviles/app/src/main/java/com/example/quiz1/fragment/AyudaFragment.kt
@@ -1,11 +1,9 @@
 package com.example.quiz1.fragment
 
 import android.os.Bundle
-import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import com.example.quiz1.R
 
@@ -15,8 +13,6 @@ class AyudaFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val view = inflater.inflate(R.layout.fragment_ayuda, container, false)
-        view.findViewById<TextView>(R.id.tvContenidoAyuda).movementMethod = LinkMovementMethod.getInstance()
-        return view
+        return inflater.inflate(R.layout.fragment_ayuda, container, false)
     }
 }

--- a/Lab4_Moviles/app/src/main/res/layout/fragment_ayuda.xml
+++ b/Lab4_Moviles/app/src/main/res/layout/fragment_ayuda.xml
@@ -4,10 +4,129 @@
     android:layout_height="match_parent"
     android:padding="16dp">
 
-    <TextView
-        android:id="@+id/tvContenidoAyuda"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:autoLink="email"
-        android:text="@string/help_text" />
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tvHelpTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/help_title"
+            android:textStyle="bold"
+            android:textSize="18sp"
+            android:layout_marginBottom="12dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/help_cursos_title"
+            android:textStyle="bold" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="@string/help_cursos_desc" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/help_carreras_title"
+            android:textStyle="bold" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="@string/help_carreras_desc" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/help_profesores_title"
+            android:textStyle="bold" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="@string/help_profesores_desc" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/help_alumnos_title"
+            android:textStyle="bold" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="@string/help_alumnos_desc" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/help_ciclos_title"
+            android:textStyle="bold" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="@string/help_ciclos_desc" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/help_oferta_title"
+            android:textStyle="bold" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="@string/help_oferta_desc" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/help_matricula_title"
+            android:textStyle="bold" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="@string/help_matricula_desc" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/help_notas_title"
+            android:textStyle="bold" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="@string/help_notas_desc" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/help_historial_title"
+            android:textStyle="bold" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="@string/help_historial_desc" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/help_seguridad_title"
+            android:textStyle="bold" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="@string/help_seguridad_desc" />
+
+    </LinearLayout>
 </ScrollView>

--- a/Lab4_Moviles/app/src/main/res/values/strings.xml
+++ b/Lab4_Moviles/app/src/main/res/values/strings.xml
@@ -10,5 +10,25 @@
     <string name="onboarding_welcome">Bienvenido a Gestión Académica</string>
     <string name="onboarding_instructions">Usa el menú lateral para acceder a cada sección y gestionar tus datos académicos.</string>
     <string name="onboarding_continue">Continuar</string>
-    <string name="help_text">Para más información sobre el uso de la app, abre el menú y elige la sección correspondiente. Si necesitas asistencia escribe a soporte@example.com.</string>
+    <string name="help_title">Guía de funcionalidades</string>
+    <string name="help_cursos_title">1. Mantenimiento de cursos</string>
+    <string name="help_cursos_desc">Permite buscar por nombre, código o carrera para administrar la oferta de cursos.</string>
+    <string name="help_carreras_title">2. Mantenimiento de carreras</string>
+    <string name="help_carreras_desc">Edite el nombre y código de cada carrera y gestione los cursos asociados.</string>
+    <string name="help_profesores_title">3. Mantenimiento de profesores</string>
+    <string name="help_profesores_desc">Busque docentes por nombre o cédula para modificar su información.</string>
+    <string name="help_alumnos_title">4. Mantenimiento de alumnos</string>
+    <string name="help_alumnos_desc">Busque estudiantes por nombre, cédula o carrera y consulte su historial académico.</string>
+    <string name="help_ciclos_title">5. Mantenimiento de ciclos</string>
+    <string name="help_ciclos_desc">Localice ciclos por año y marque cuál se encuentra activo.</string>
+    <string name="help_oferta_title">6. Oferta académica</string>
+    <string name="help_oferta_desc">Consulte los cursos disponibles por carrera y ciclo, además de gestionar los grupos.</string>
+    <string name="help_matricula_title">7. Matrícula de estudiantes</string>
+    <string name="help_matricula_desc">Revise o modifique la matrícula en el ciclo activo y cambie de ciclo si es necesario.</string>
+    <string name="help_notas_title">8. Registro de notas</string>
+    <string name="help_notas_desc">Los profesores visualizan sus grupos asignados y registran o ajustan las calificaciones.</string>
+    <string name="help_historial_title">9. Consulta de historial</string>
+    <string name="help_historial_desc">Los alumnos revisan sus cursos aprobados y el detalle de cada matrícula.</string>
+    <string name="help_seguridad_title">10. Seguridad</string>
+    <string name="help_seguridad_desc">Los administradores gestionan usuarios con permisos de administración y matrícula.</string>
 </resources>


### PR DESCRIPTION
## Summary
- replace old help_text with a complete guide of functionalities
- redesign help fragment layout with multiple text sections
- simplify `AyudaFragment` logic

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e794bf80832fb6f34d0df362ca19